### PR TITLE
Allow configuration of MESSAGE_PORT

### DIFF
--- a/src/static/webpack/index.js
+++ b/src/static/webpack/index.js
@@ -92,9 +92,11 @@ export async function startDevServer({ config }) {
   // or environment variables
   const intendedPort =
     (config.devServer && config.devServer.port) || process.env.PORT || 3000
+  const intendedMessagePort =
+    (config.messagePort) || process.env.MESSAGE_PORT || 4000
   const port = await findAvailablePort(Number(intendedPort))
   // Find an available port for messages, as long as it's not the devServer port
-  const messagePort = await findAvailablePort(4000, [port])
+  const messagePort = await findAvailablePort(intendedMessagePort, [port])
   if (intendedPort !== port) {
     time(
       chalk.red(


### PR DESCRIPTION
## Description

Allow passing of message port (4000) through env/config

## Motivation and Context

This allows passing of custom port, for cases when the port is already being used. For some reason, `findAvailablePort` is not working as intended and it masks the server I'm using

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them